### PR TITLE
fix status message to align with status code

### DIFF
--- a/app/src/main/java/http_server/ResponseBuilder.java
+++ b/app/src/main/java/http_server/ResponseBuilder.java
@@ -14,11 +14,11 @@ public class ResponseBuilder {
     String method = request.getMethod();
 
     if (!routeValidator.hasPath(path)) {
-      return handler.buildUnexpectedResponse("404");
+      return handler.buildUnexpectedResponse("404 Not Found");
     }
 
     if (!routeValidator.hasMethod(path, method)) {
-      return handler.buildMethodOptionsResponse("allow", "GET, HEAD, OPTIONS", "405");
+      return handler.buildMethodOptionsResponse("allow", "GET, HEAD, OPTIONS", "405 Method Not Allowed");
     }
 
     if (path != null && method != null) {
@@ -49,52 +49,52 @@ public class ResponseBuilder {
       }
     }
 
-    return handler.buildUnexpectedResponse("405");
+    return handler.buildUnexpectedResponse("405 Method Not Allowed");
   }
 
   private Response handleSimpleGetWithBodyResponse(String method) {
     if (method.equals("HEAD")) {
-      return handler.buildHeadResponse("200");
+      return handler.buildHeadResponse("200 OK");
     } else {
-      return handler.buildResponse("200", "Hello world");
+      return handler.buildResponse("200 OK", "Hello world");
     }
   }
 
   private Response handleSimpleGetResponse(String method) {
     if (method.equals("HEAD")) {
-      return handler.buildHeadResponse("200");
+      return handler.buildHeadResponse("200 OK");
     } else {
-      return handler.buildResponse("200", "");
+      return handler.buildResponse("200 OK", "");
     }
   }
 
   private Response handleEchoBodyResponse(String method, String body) {
     if (method.equals("POST") && body != null) {
-      return handler.buildResponse("200", body);
+      return handler.buildResponse("200 OK", body);
     }
-    return handler.buildUnexpectedResponse("405");
+    return handler.buildUnexpectedResponse("405 Method Not Allowed");
   }
 
   private Response handleHeadRequestResponse(String method) {
     if (method.equals("HEAD")) {
-      return handler.buildHeadResponse("200");
+      return handler.buildHeadResponse("200 OK");
     } else {
-      return handler.buildNonHeadResponse("200");
+      return handler.buildNonHeadResponse("200 OK");
     }
   }
 
   private Response handleMethodOptionsResponse(String method, String allowedMethods) {
     if (method.equals("OPTIONS")) {
-      return handler.buildMethodOptionsResponse("allow", allowedMethods, "200");
+      return handler.buildMethodOptionsResponse("allow", allowedMethods, "200 OK");
     }
-    return handler.buildUnexpectedResponse("405");
+    return handler.buildUnexpectedResponse("405 Method Not Allowed");
   }
 
   private Response handleRedirectResponse(String method) {
     if (method.equals("GET")) {
-      return handler.buildRedirectResponse("location", "http://127.0.0.1:8080/simple_get", "301");
+      return handler.buildRedirectResponse("location", "http://127.0.0.1:8080/simple_get", "301 Moved Permanently");
     }
-    return handler.buildUnexpectedResponse("405");
+    return handler.buildUnexpectedResponse("405 Method Not Allowed");
   }
 }
 

--- a/app/src/main/java/http_server/ResponseFormatter.java
+++ b/app/src/main/java/http_server/ResponseFormatter.java
@@ -6,7 +6,7 @@ public class ResponseFormatter {
 
   public String format(Response response) {
     StringBuilder responseBuilder = new StringBuilder();
-    responseBuilder.append("HTTP/1.1 " + response.getResponseStatus() + " OK\r\n");
+    responseBuilder.append("HTTP/1.1 " + response.getResponseStatus() + "\r\n");
 
     for (Map.Entry<String, String> entry : response.getResponseHeaders().entrySet()) {
       responseBuilder

--- a/app/src/test/java/http_server/ResponseFormatterTest.java
+++ b/app/src/test/java/http_server/ResponseFormatterTest.java
@@ -21,7 +21,7 @@ public class ResponseFormatterTest {
     responseHeaders.put("Server", "Test Server");
 
     when(response.getResponseHeaders()).thenReturn(responseHeaders);
-    when(response.getResponseStatus()).thenReturn("200");
+    when(response.getResponseStatus()).thenReturn("200 OK");
     when(response.getResponseBody()).thenReturn("Hello, world!");
 
     ResponseFormatter responseFormatter = new ResponseFormatter();


### PR DESCRIPTION
## Changes made:

1. changed the status code string to also include its corresponding message.

## Comments:
I considered implementing a Hashmap with status codes as keys and their corresponding status messages as values. However, I concluded that this approach would be a more compact and graceful refactor, at least for the time being. My rationale was that employing a Hashmap would necessitate creating a dedicated class with getter and formatter methods, which seemed excessive for this particular refactor.

[ticket](https://trello.com/c/mkqzMqi9)